### PR TITLE
GetBoneTransform()で発生するIndexOutOfRangeExpeptionの修正

### DIFF
--- a/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/HumanoidPoses.cs
+++ b/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/HumanoidPoses.cs
@@ -83,7 +83,7 @@ namespace Entum
 #if UNITY_EDITOR
         //Genericなanimファイルとして出力する。
         [ContextMenu("Export as generic animation clips")]
-        public void ExportgenericAnim()
+        public void ExportGenericAnim()
         {
             var clip = new AnimationClip {frameRate = 30,};
             AnimationUtility.SetAnimationClipSettings(clip, new AnimationClipSettings() {loopTime = false,});

--- a/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/MotionDataPlayer.cs
+++ b/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/MotionDataPlayer.cs
@@ -80,7 +80,7 @@ namespace Entum
         }
 
 
-        void SetHumanPose(int frame)
+        void SetHumanPose()
         {
             var pose = new HumanPose();
             pose.muscles = _recordedMotionData.Poses[_frameIndex].Muscles;
@@ -150,7 +150,7 @@ namespace Entum
         {
             if (!_playing) return;
             _playingTime += Time.deltaTime;
-            SetHumanPose(_frameIndex);
+            SetHumanPose();
         }
     }
 }

--- a/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/MotionDataRecorder.cs
+++ b/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/MotionDataRecorder.cs
@@ -189,7 +189,6 @@ namespace Entum
                 serializedPose.BodyRotation = _currentPose.bodyRotation;
                 serializedPose.FrameCount = _frameIndex;
                 serializedPose.Muscles = new float[_currentPose.muscles.Length];
-                serializedPose.FrameCount = _frameIndex;
                 serializedPose.Time = _recordedTime;
                 for (int i = 0; i < serializedPose.Muscles.Length; i++)
                 {

--- a/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/MotionDataRecorder.cs
+++ b/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/MotionDataRecorder.cs
@@ -58,6 +58,8 @@ namespace Entum
             HumanBodyBones[] values = HumanBodyBones.GetValues(typeof(HumanBodyBones)) as HumanBodyBones[];
             foreach (HumanBodyBones b in values)
             {
+                if (b < 0 || b >= HumanBodyBones.LastBone) { continue; }
+
                 Transform t = animator.GetBoneTransform(b);
                 if (t != null )
                 {


### PR DESCRIPTION
モーションの収録時に以下のエラーが発生していたので、メッセージに合わせて条件分岐を追加しました。

> IndexOutOfRangeException: humanBoneId must be between 0 and LastBone UnityEngine.Animator.GetBoneTransform (HumanBodyBones humanBoneId) (at C:/buildslave/unity/build/Runtime/Animation/ScriptBindings/Animator.bindings.cs:986i)

エラー箇所：https://github.com/Unity-Technologies/UnityCsReference/blob/master/Runtime/Animation/ScriptBindings/Animator.bindings.cs#L971-L972

動作確認環境：Windows 10, Unity2018.2.1f1. 

また、軽微な修正を行いました。