### PR TITLE
Decrease GC Alloc during recording

### DIFF
--- a/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/HumanoidPoses.cs
+++ b/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/HumanoidPoses.cs
@@ -363,9 +363,14 @@ namespace Entum
                 public Vector3 LocalPosition;
                 public Quaternion LocalRotation;
 
+                private static Dictionary<Transform, string> _pathCache = new Dictionary<Transform, string>();
+
                 private static string BuildRelativePath(Transform root, Transform target)
                 {
                     var path = "";
+                    _pathCache.TryGetValue(target, out path);
+                    if(path != null) return path;
+
                     var current = target;
                     while (true)
                     {
@@ -376,6 +381,8 @@ namespace Entum
 
                         current = current.parent;
                     }
+
+                    _pathCache.Add(target, path);
 
                     return path;
                 }


### PR DESCRIPTION
レコーディング中、毎フレームおよそ100KB～200KB程度のGC Allocが生じるのを改善しました。
GC Allocの量はモデルのボーン数や名前によって変化していると思われます。

# 確認環境
- Unity 2018.2.20f1
- Windows10
- i7-6700K
- 16GB Mem
- GTX 1070

上記環境で、ユニティちゃんのCandy Rock Starのモーションを記録して確認しました。

# 改善前
毎フレームのGC Alloc（Deep Profile状態でのスクショ。以下同じ）
![2019-01-25_172606](https://user-images.githubusercontent.com/1302700/51736595-cb238d00-20cd-11e9-8723-22904f7d4404.jpg)

GC Collectによるスパイク
![2019-01-25_172649](https://user-images.githubusercontent.com/1302700/51736604-cfe84100-20cd-11e9-93ea-62d1e6d85fda.jpg)

# 改善後
毎フレームのGC Alloc
![2019-01-25_180608](https://user-images.githubusercontent.com/1302700/51736614-d4145e80-20cd-11e9-8434-ee8fd7d51cd7.jpg)

# 制約
- 利用中にボーン名や構造に変更があると正しく動作しないと思います（キャッシュが更新されないため）

# その他
- キャッシュがstaticですが、シングルスレッド前提なのと、複数キャラクター（複数のRecorder）を同時に利用した場合もTransformが重複するといったケースは無いと思われるため問題無いと判断しました。