### PR TITLE
fix_issue_17 (facial recording problem)

### DIFF
--- a/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/FaceAnimationRecorder.cs
+++ b/EasyMotionRecorder/Assets/EasyMotionRecorder/Scripts/FaceAnimationRecorder.cs
@@ -267,7 +267,7 @@ namespace Entum
                     pathsb.Insert(0, "/").Insert(0, trans.name);
                 }
 
-                //pathにはBlednshapeのベース名が入る
+                //pathにはBlendshapeのベース名が入る
                 //U_CHAR_1:SkinnedMeshRendererみたいなもの
                 var path = pathsb.ToString();
 


### PR DESCRIPTION
顔のAnimationCurveのkeypointがSparceだったときに、曲線補完することで変な値(200以上や0未満)になってしまっているのを、大量にキーを打つことで解決します。

https://github.com/duo-inc/EasyMotionRecorder/issues/17

副作用としてキーが増えてしまいますが、誤った値になるよりは冗長で正確なキーが打たれた方が嬉しいです。